### PR TITLE
Fix for "Undefined symbols"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ export PATH := bin:$(PATH)
 default: $(OUT)
 
 $(OUT): $(OBJS)
-	$(CC) $(LDFLAGS) -shared -o $@ $^
+	$(CC) $(LDFLAGS) -shared -undefined dynamic_lookup -o $@ $^
 
 obj/simplelib_wrap.o: simplelib_wrap.cxx inc/simpleclass.h
 	$(CC) $(CXXFLAGS) $(INCLUDES) -fpic -c $< -o $@


### PR DESCRIPTION
I get this strange errors while building so file:

```
Undefined symbols for architecture x86_64:
  "__cgo_allocate", referenced from:
      _swig_goallocate(unsigned long) in geobase_wrap.o
  "__cgo_topofstack", referenced from:
      _swig_topofstack() in geobase_wrap.o
  "_crosscall2", referenced from:
      _swig_goallocate(unsigned long) in geobase_wrap.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [lib/libgeobase.so] Error 1
```
## 

From https://groups.google.com/forum/#!topic/golang-nuts/NX9RpdHA8BU
